### PR TITLE
Make installation idempotent.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,27 +4,21 @@
     singularity_version: "{{ singularity_version | default(singularity_default_version) }}"
 
 - name: Check singularity version
-  command: singularity version
+  shell:
+    cmd: "{{ 
+      'singularity version' 
+      if singularity_version is version('3.0', operator='ge') 
+      else 'singularity --version' }}"
+    strip_empty_ends: true
   register: singularity_version_check
-  # 127 means command not found. Stdout will be empty.
-  failed_when: 'singularity_version_check.rc != 0 and singularity_version_check != 127'
-  when: singularity_version is version('3.0', operator='ge')
-
-- name: Check singularity version
-  command: singularity --version
-  register: singularity_version_check
-  # 127 means command not found. Stdout will be empty.
-  failed_when: 'singularity_version_check.rc != 0 and singularity_version_check != 127'
-  when: singularity_version is version('3.0', operator='lt')
+  # When the command is not found, stdout will be empty (message in stderr)
+  # The correct version installed check will thus return false
+  failed_when: false
+  changed_when: false
 
 - name: Check if correct version is installed
   set_fact:
-    singularity_installed: "{{ singularity_version_check.stdout | trim }} == singularity_version"
-
-- name: Show singularity_installed
-  debug:
-    var:  singularity_installed
-    verbosity: 1
+    singularity_installed: "{{ singularity_version_check.stdout == singularity_version }}"
 
 - name: if singularity_version is pre-3.0
   include: singularity-pre-3.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,14 @@
   register: singularity_version_check
   # 127 means command not found. Stdout will be empty.
   failed_when: 'singularity_version_check.rc != 0 and singularity_version_check != 127'
+  when: singularity_version is version('3.0', operator='ge')
+
+- name: Check singularity version
+  command: singularity --version
+  register: singularity_version_check
+  # 127 means command not found. Stdout will be empty.
+  failed_when: 'singularity_version_check.rc != 0 and singularity_version_check != 127'
+  when: singularity_version is version('3.0', operator='lt')
 
 - name: Check if correct version is installed
   set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,10 +3,25 @@
   set_fact:
     singularity_version: "{{ singularity_version | default(singularity_default_version) }}"
 
+- name: Check singularity version
+  command: singularity version
+  register: singularity_version_check
+  # 127 means command not found. Stdout will be empty.
+  failed_when: 'singularity_version_check.rc != 0 and singularity_version_check != 127'
+
+- name: Check if correct version is installed
+  set_fact:
+    singularity_installed: "{{ singularity_version_check.stdout | trim }} == singularity_version"
+
+- name: Show singularity_installed
+  debug:
+    var:  singularity_installed
+    verbosity: 1
+
 - name: if singularity_version is pre-3.0
   include: singularity-pre-3.yml
-  when: singularity_version is version('3.0', operator='lt')
+  when: singularity_version is version('3.0', operator='lt') and not singularity_installed
 
 - name: if singularity_version is 3.0 or later
   include: singularity-post-3.yml
-  when: singularity_version is version('3.0', operator='ge')
+  when: singularity_version is version('3.0', operator='ge') and not singularity_installed

--- a/tasks/singularity-post-3.yml
+++ b/tasks/singularity-post-3.yml
@@ -1,6 +1,6 @@
 ---
 # tasks file for ansible-singularity
-- name: Ubuntu package installation for v3.0 or newer
+- name: Debian family package installation for v3.0 or newer
   apt:
     name: 
       - build-essential
@@ -14,9 +14,9 @@
       - cryptsetup
     state: latest
     update_cache: yes
-  when: ansible_distribution == "Ubuntu"
+  when: ansible_os_family == "Debian"
 
-- name: CentOS package installation for v3.0 or newer
+- name: RedHat family package installation for v3.0 or newer
   yum:
     name: 
       - "@Development Tools"
@@ -30,7 +30,7 @@
       - cryptsetup
     state: latest
     update_cache: yes
-  when: ansible_distribution == "CentOS"
+  when: ansible_os_family == "RedHat"
 
 - name: download the singularity release
   get_url:

--- a/tasks/singularity-post-3.yml
+++ b/tasks/singularity-post-3.yml
@@ -12,7 +12,7 @@
       - pkg-config
       - git
       - cryptsetup
-    state: latest
+    state: present
     update_cache: yes
   when: ansible_os_family == "Debian"
 
@@ -28,7 +28,7 @@
       - pkgconfig
       - git
       - cryptsetup
-    state: latest
+    state: present
     update_cache: yes
   when: ansible_os_family == "RedHat"
 

--- a/tasks/singularity-pre-3.yml
+++ b/tasks/singularity-pre-3.yml
@@ -7,7 +7,7 @@
       - autoconf
       - libtool
       - libarchive-dev
-    state: latest
+    state: present
     update_cache: yes
   when: ansible_os_family == "Debian"
 
@@ -17,7 +17,7 @@
       - autoconf
       - libtool
       - libarchive-devel
-    state: latest
+    state: present
     update_cache: yes
   when: ansible_os_family == "RedHat"
 

--- a/tasks/singularity-pre-3.yml
+++ b/tasks/singularity-pre-3.yml
@@ -1,6 +1,6 @@
 ---
 # tasks file for ansible-singularity
-- name: Ubuntu package installation for pre-3.0
+- name: Debian family package installation for pre-3.0
   apt:
     name:
       - autogen
@@ -9,9 +9,9 @@
       - libarchive-dev
     state: latest
     update_cache: yes
-  when: ansible_distribution == "Ubuntu"
+  when: ansible_os_family == "Debian"
 
-- name: CentOS package installation for pre-3.0
+- name: RedHat family package installation for pre-3.0
   yum:
     name:
       - autoconf
@@ -19,7 +19,7 @@
       - libarchive-devel
     state: latest
     update_cache: yes
-  when: ansible_distribution == "CentOS"
+  when: ansible_os_family == "RedHat"
 
 - name: clone the singularity repo for pre-3.0
   git:


### PR DESCRIPTION
Hi @edwins ,

First of all thanks for this ansible role. I first tried the [other singularity role](https://github.com/abims-sbr/ansible-singularity) but it is way more involved, and it depends on golang dep, which is deprecated. 

I like that this role is simple and efficient. Because of its simplicity it just works.

One disadvantage I noticed is that the installation always runs, even if singularity is already installed. This slows down deployment, and is especially annoying when you made a small update somewhere else in your playbook or when you are testing.  I also noticed that the package installation won't happen on Debian, even though the package names are the same as in Ubuntu.

So with this PR:

- `singularity version` is run to get the version. (`singularity --version` when the version is lower than 3). If singularity is not installed, then this command returns an empty string `''`. 
- The checked version is compared to the desired version.
-  If the desired version is not installed the installation runs.

Also:
- Use `ansible_os_family` because package names among the Debian family and among the RedHat family are interchangable.
- Use `state: present` for the packages. There is no reason to keep updating the build packages on rerunning the role. Most distributions have only one version in their repo anyway.

