### PR TITLE
Sylabs now singularityware

### DIFF
--- a/tasks/singularity-post-3.yml
+++ b/tasks/singularity-post-3.yml
@@ -35,7 +35,7 @@
 
 - name: download the singularity release
   get_url:
-    url: "https://github.com/sylabs/singularity/releases/download/v{{singularity_version}}/singularity-ce-{{singularity_version}}.tar.gz"
+    url: "https://github.com/singularityware/singularity/releases/download/v{{singularity_version}}/singularity-ce-{{singularity_version}}.tar.gz"
     dest: "/tmp/singularity-{{singularity_version}}.tar.gz"
     mode: 0644
 


### PR DESCRIPTION
sylabs name has been "improved" so the current url template is broken.